### PR TITLE
Fix wrreq metric

### DIFF
--- a/libvirt_exporter.go
+++ b/libvirt_exporter.go
@@ -325,7 +325,7 @@ func CollectDomain(ch chan<- prometheus.Metric, stat libvirt.DomainStats) error 
 				prometheus.CounterValue,
 				float64(disk.WrReqs),
 				domainName,
-				disk.Name,
+				DiskSource,
 				disk.Name)
 		}
 		if disk.WrTimesSet {


### PR DESCRIPTION
Hi,
For now source_file label is the same as target_device in 'write_requests_total'.
This fixes 'write requests total' metric.